### PR TITLE
メッセージの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -49,8 +49,8 @@ $(document).on('turbolinks:load', function(){
         console.log('error');
       });
     };
-    const group_messaes_path = /http:\/\/.+\/groups\/\d+\/messages/;
-    if(window.location.href.match(group_messaes_path)){
+    const group_messages_path = /http:\/\/.+\/groups\/\d+\/messages/;
+    if(window.location.href.match(group_messages_path)){
       setInterval(reloadMessages, 5000);
     };
   });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,12 +1,30 @@
 $(function() {
-  //省略
+  var buildMessageHTML = function(message) {
+    var body = message.body ? `${message.body}` : "";
+    var image = message.image ? `<img src="${message.image}">` : ""
+    var html = `<li class="message", data-message_id="${message.id}">
+                  <ul class="message__info">
+                    <li class="message__info message__user-name">
+                      ${message.user_name}
+                    </li>
+                    <li class="message__info message__date">
+                      ${message.created_at}
+                    </li>
+                  </ul>
+                  <div class="message__text">
+                    ${body}
+                  </div>
+                    ${image}
+                </li>`
+    return html;
+  }
   
     var reloadMessages = function() {
       //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
-      last_message_id = $(".message").data("message_id")
+      last_message_id = $(".message").data("message_id").push
       $.ajax({
         //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
-        url: `/groups/${group}/api/messages`,
+        url: "api/messages",
         //ルーティングで設定した通りhttpメソッドをgetに指定
         type: 'get',
         dataType: 'json',
@@ -14,7 +32,15 @@ $(function() {
         data: {id: last_message_id}
       })
       .done(function(messages) {
-        console.log('success');
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message){
+          insertHTML += buildMessageHTML(message);
+        });
+        //メッセージが入ったHTMLを取得
+        //メッセージを追加
+        $("messages").append(insertHTML);
       })
       .fail(function() {
         console.log('error');

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,0 +1,23 @@
+$(function() {
+  //省略
+  
+    var reloadMessages = function() {
+      //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+      last_message_id = $(".message").data("message_id")
+      $.ajax({
+        //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+        url: `/groups/${group}/api/messages`,
+        //ルーティングで設定した通りhttpメソッドをgetに指定
+        type: 'get',
+        dataType: 'json',
+        //dataオプションでリクエストに値を含める
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        console.log('success');
+      })
+      .fail(function() {
+        console.log('error');
+      });
+    };
+  });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,27 +1,29 @@
-$(function() {
-  var buildMessageHTML = function(message) {
-    var body = message.body ? `${message.body}` : "";
-    var image = message.image ? `<img src="${message.image}">` : ""
-    var html = `<li class="message", data-message_id="${message.id}">
-                  <ul class="message__info">
-                    <li class="message__info message__user-name">
-                      ${message.user_name}
-                    </li>
-                    <li class="message__info message__date">
-                      ${message.created_at}
-                    </li>
-                  </ul>
-                  <div class="message__text">
-                    ${body}
-                  </div>
-                    ${image}
-                </li>`
-    return html;
-  }
-  
+$(document).on('turbolinks:load', function(){
+  $(function() {
+    var buildMessageHTML = function(message) {
+      var body = message.body ? `${message.body}` : "";
+      var image = message.image_url ? `<img src="${message.image_url}">` : ""
+      var html = `<li class="message", data-message-id="${message.id}">
+                    <ul class="message__info">
+                      <li class="message__info message__user-name">
+                        ${message.user_name}
+                      </li>
+                      <li class="message__info message__date">
+                        ${message.created_at}
+                      </li>
+                    </ul>
+                    <div class="message__text">
+                      ${body}
+                    </div>
+                      ${image}
+                  </li>`
+      return html;
+    }
+    
     var reloadMessages = function() {
       //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
-      last_message_id = $(".message").data("message_id").push
+      last_message_id = $(".message:last").data("message-id");
+      // debugger;
       $.ajax({
         //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
         url: "api/messages",
@@ -40,10 +42,16 @@ $(function() {
         });
         //メッセージが入ったHTMLを取得
         //メッセージを追加
-        $("messages").append(insertHTML);
+        $(".messages").append(insertHTML);
+        $("html, body").animate({scrollTop: $(document).height()});
       })
       .fail(function() {
         console.log('error');
       });
     };
+    const group_messaes_path = /http:\/\/.+\/groups\/\d+\/messages/;
+    if(window.location.href.match(group_messaes_path)){
+      setInterval(reloadMessages, 5000);
+    };
   });
+});

--- a/app/assets/javascripts/posts_message.js
+++ b/app/assets/javascripts/posts_message.js
@@ -3,7 +3,7 @@ $(document).on('turbolinks:load', function(){
     function buildHTML(message){
       var body = message.body ? `${message.body}` : "";
       var image = message.image_url ? `<img src="${message.image_url}">` : ""
-      var html = `<li class="message">
+      var html = `<li class="message", data-message_id="${message.id}">
                     <ul class="message__info">
                       <li class="message__info message__user-name">
                         ${message.user_name}

--- a/app/assets/javascripts/posts_message.js
+++ b/app/assets/javascripts/posts_message.js
@@ -2,7 +2,7 @@ $(document).on('turbolinks:load', function(){
   $(function(){
     function buildHTML(message){
       var body = message.body ? `${message.body}` : "";
-      var image = message.image_url ? `<img src="${message.image_url}">` : ""
+      var image = message.image ? `<img src="${message.image}">` : ""
       var html = `<li class="message", data-message_id="${message.id}">
                     <ul class="message__info">
                       <li class="message__info message__user-name">
@@ -33,6 +33,7 @@ $(document).on('turbolinks:load', function(){
         contentType: false
       })
       .done(function(message){
+        debugger;
         var html = buildHTML(message);
         $(".messages").append(html);
         $("#chat-form")[0].reset();

--- a/app/assets/javascripts/posts_message.js
+++ b/app/assets/javascripts/posts_message.js
@@ -2,8 +2,8 @@ $(document).on('turbolinks:load', function(){
   $(function(){
     function buildHTML(message){
       var body = message.body ? `${message.body}` : "";
-      var image = message.image ? `<img src="${message.image}">` : ""
-      var html = `<li class="message", data-message_id="${message.id}">
+      var image = message.image_url ? `<img src="${message.image_url}">` : ""
+      var html = `<li class="message", data-message-id="${message.id}">
                     <ul class="message__info">
                       <li class="message__info message__user-name">
                         ${message.user_name}
@@ -33,7 +33,6 @@ $(document).on('turbolinks:load', function(){
         contentType: false
       })
       .done(function(message){
-        debugger;
         var html = buildHTML(message);
         $(".messages").append(html);
         $("#chat-form")[0].reset();

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_messge_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -6,5 +6,9 @@ class Api::MessagesController < ApplicationController
     last_message_id = params[:id].to_i
     # 取得したグループでのメッセージ達から、idがlast_messge_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+    respond_to do |format|
+      format.json
+      # format.html
+    end
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -8,7 +8,7 @@ class Api::MessagesController < ApplicationController
     @messages = group.messages.includes(:user).where("id > #{last_message_id}")
     respond_to do |format|
       format.json
-      # format.html
+      format.html
     end
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.body message.body
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.body message.body
-  json.image message.image
-  json.created_at message.created_at
+  json.image_url message.image.url
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-%li{class: "message"}
+%li{class: "message", data: {message_id: message.id}}
   %ul{class: "message__info"}
     %li{class: "message__info message__user-name"}
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,3 +1,4 @@
+json.id @message.id
 json.body @message.body
 json.user_name @message.user.name
 json.image_url @message.image.url

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.id @message.id
-json.{@message, :body, :image}
+json.(@message, :body, :image)
 json.user_name @message.user.name
 json.image_url @message.image.url
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.id @message.id
-json.body @message.body
+json.{@message, :body, :image}
 json.user_name @message.user.name
 json.image_url @message.image.url
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
メッセージの自動更新機能の実装。

[自動更新例](https://gyazo.com/b7c665b15651ef77dbdb00af61b85095)


# Why
当該機能実装前は、投稿した本人の画面のみしか自動更新されておらず、他の画面では新規に投稿されたメッセージはリロードを挟まなければ取得することができなかったため。
